### PR TITLE
refactor(processor-builder): apply readonly property to enhance immut…

### DIFF
--- a/src/ProcessorBuilder.php
+++ b/src/ProcessorBuilder.php
@@ -11,32 +11,48 @@ use KaririCode\Contract\Processor\ProcessorRegistry;
 
 class ProcessorBuilder
 {
-    public function __construct(private ProcessorRegistry $registry)
+    public function __construct(private readonly ProcessorRegistry $registry)
     {
     }
 
-    public function build(string $context, string $name, array $config = []): Processor
+    public function build(string $context, string $name, array $processorConfig = []): Processor
     {
         $processor = $this->registry->get($context, $name);
-        if ($processor instanceof ConfigurableProcessor && !empty($config)) {
-            $processor->configure($config);
+        if ($processor instanceof ConfigurableProcessor && !empty($processorConfig)) {
+            $processor->configure($processorConfig);
         }
 
         return $processor;
     }
 
+    /**
+     * @param array<int|string, string|array<string, mixed>> $processorSpecs
+     */
     public function buildPipeline(string $context, array $processorSpecs): Pipeline
     {
         $pipeline = new ProcessorPipeline();
-        foreach ($processorSpecs as $name => $config) {
-            if (is_int($name)) {
-                $name = $config;
-                $config = [];
-            }
-            $processor = $this->build($context, $name, $config);
+        foreach ($processorSpecs as $key => $spec) {
+            $processorName = $this->resolveProcessorName($key, $spec);
+            $processorConfig = $this->resolveProcessorConfig($key, $spec);
+            $processor = $this->build($context, $processorName, $processorConfig);
             $pipeline->addProcessor($processor);
         }
 
         return $pipeline;
+    }
+
+    private function isUnnamedProcessor(int|string $key): bool
+    {
+        return is_int($key);
+    }
+
+    private function resolveProcessorName(int|string $key, string|array $spec): string
+    {
+        return $this->isUnnamedProcessor($key) ? (string) $spec : (string) $key;
+    }
+
+    private function resolveProcessorConfig(int|string $key, string|array $spec): array
+    {
+        return $this->isUnnamedProcessor($key) ? [] : (array) $spec;
     }
 }


### PR DESCRIPTION
…ability

- Marked the $registry property as readonly to ensure immutability and prevent modification after construction.
- Improved code readability and reliability by enforcing immutability for the ProcessorRegistry dependency.
- This change provides minor performance improvements due to reduced internal checks and supports better optimization opportunities by PHP.