### PR TITLE
fix(validator): resolve processor state retention issues

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "kariricode/contract",
-            "version": "v2.7.7",
+            "version": "v2.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KaririCode-Framework/kariricode-contract.git",
-                "reference": "bd78b746e4704ef36402478f7e6460a001fc579f"
+                "reference": "72c834a3afe2dbded8f6a7f96005635424636d4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KaririCode-Framework/kariricode-contract/zipball/bd78b746e4704ef36402478f7e6460a001fc579f",
-                "reference": "bd78b746e4704ef36402478f7e6460a001fc579f",
+                "url": "https://api.github.com/repos/KaririCode-Framework/kariricode-contract/zipball/72c834a3afe2dbded8f6a7f96005635424636d4b",
+                "reference": "72c834a3afe2dbded8f6a7f96005635424636d4b",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
                 "issues": "https://github.com/KaririCode-Framework/kariricode-contract/issues",
                 "source": "https://github.com/KaririCode-Framework/kariricode-contract"
             },
-            "time": "2024-10-18T13:01:57+00:00"
+            "time": "2024-10-24T18:51:39+00:00"
         },
         {
             "name": "kariricode/data-structure",
@@ -1655,16 +1655,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.4.1",
+            "version": "11.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7875627f15f4da7e7f0823d1f323f7295a77334e"
+                "reference": "1863643c3f04ad03dcb9c6996c294784cdda4805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7875627f15f4da7e7f0823d1f323f7295a77334e",
-                "reference": "7875627f15f4da7e7f0823d1f323f7295a77334e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1863643c3f04ad03dcb9c6996c294784cdda4805",
+                "reference": "1863643c3f04ad03dcb9c6996c294784cdda4805",
                 "shasum": ""
             },
             "require": {
@@ -1678,21 +1678,21 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.6",
+                "phpunit/php-code-coverage": "^11.0.7",
                 "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.1",
-                "sebastian/comparator": "^6.1.0",
+                "sebastian/comparator": "^6.1.1",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
                 "sebastian/exporter": "^6.1.3",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
                 "sebastian/type": "^5.1.0",
-                "sebastian/version": "^5.0.1"
+                "sebastian/version": "^5.0.2"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -1735,7 +1735,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.4.1"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.4.2"
             },
             "funding": [
                 {
@@ -1751,7 +1751,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-08T15:38:37+00:00"
+            "time": "2024-10-19T13:05:19+00:00"
         },
         {
             "name": "psr/container",

--- a/src/ProcessorPipeline.php
+++ b/src/ProcessorPipeline.php
@@ -6,6 +6,7 @@ namespace KaririCode\ProcessorPipeline;
 
 use KaririCode\Contract\Processor\Pipeline;
 use KaririCode\Contract\Processor\Processor;
+use KaririCode\Contract\Processor\ValidatableProcessor;
 
 class ProcessorPipeline implements Pipeline
 {
@@ -22,7 +23,14 @@ class ProcessorPipeline implements Pipeline
     {
         return array_reduce(
             $this->processors,
-            fn ($carry, Processor $processor) => $processor->process($carry),
+            static function ($carry, Processor $processor): mixed {
+                // Reset the processor's state if it's a ValidatableProcessor
+                if ($processor instanceof ValidatableProcessor) {
+                    $processor->reset();
+                }
+
+                return $processor->process($carry);
+            },
             $input
         );
     }


### PR DESCRIPTION
Add reset capabilities to validator processors to prevent state leakage between validations. This resolves the issue where validation errors were persisting across multiple validation cycles.

- Add reset() method to ValidatableProcessor interface
- Implement reset() in AbstractValidatorProcessor
- Update ProcessorPipeline to call reset() before processing
- Add proper documentation for new methods